### PR TITLE
add view article tags feature

### DIFF
--- a/src/components/article/ReadArticle.jsx
+++ b/src/components/article/ReadArticle.jsx
@@ -201,14 +201,6 @@ export class ReadArticle extends Component {
                 <h1>{singleArticle.title && reactHtml(singleArticle.title)}</h1>
                 <Author />
                 <SocialMedia />
-                {singleArticle.taglist !== undefined &&
-                singleArticle.taglist.length !== 0
-                  ? singleArticle.taglist.map(tag => (
-                      <div className="tagList" key={id}>
-                        #{tag}
-                      </div>
-                    ))
-                  : ''}
               </div>
               <div className="contentBody">
                 {singleArticle.image !== 'null' &&
@@ -221,6 +213,16 @@ export class ReadArticle extends Component {
                 )}
                 <p id="articleBody" className="articleBody">
                   {singleArticle.body && reactHtml(singleArticle.body)}
+                  <br />
+                  {singleArticle.taglist !== undefined &&
+                  singleArticle.taglist.length !== 0
+                    ? singleArticle.taglist.map(tag => (
+                        <span className="tagList" key={id}>
+                          #{tag}
+                        </span>
+                      ))
+                    : ''}
+                  <br />
                 </p>
                 <hr />
                 <div className="rating">

--- a/src/styles/css/article.css
+++ b/src/styles/css/article.css
@@ -587,11 +587,6 @@ div.alert {
 }
 
 .tagList {
-  padding: 2px;
-  margin: 0.5rem 0.25rem;
-  border-radius: 2px;
-  background-color: #4b4b4b;
-  color: #fff;
   display: inline-block;
   padding: 5px;
   cursor: pointer;

--- a/src/styles/scss/article.scss
+++ b/src/styles/scss/article.scss
@@ -583,11 +583,13 @@ $brand-colors: (
 }
 
 .tagList {
-  @include buttonCommonStyles;
-  background-color: #4b4b4b;
-  color: #fff;
   display: inline-block;
-  padding: 5px;
+  margin: 20px 10px 20px 0;
+  border-radius: 4px;
+  background-color: #ccc;
+  color: #333;
+  font-size: 14px;
+  padding: 0px 5px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
#### What does this PR do?
This Feature will allow a user to view tags of an article.
#### Description of Task to be completed?
- Added a section of displaying an article tag after the body of an article.
#### How should this be manually tested?
- Clone the repo from https://github.com/andela/strikers-ah-frontend.git
- Got to where you cloned the repo and open a terminal/cmd there.
- Checkout to `develop` branch by typing `git checkout develop` in your terminal.
- Type `npm install` to install necessary dependencies.
- Then start the server with `npm start`.
- The home page will open up in your default browser and then you can open an article and view all tags related to that article.
#### What are the relevant pivotal tracker stories?
164489753
#### Screenshots (if appropriate).
<img width="1134" alt="Screen Shot 2019-06-20 at 18 31 34" src="https://user-images.githubusercontent.com/37753967/59865593-b0f29000-9389-11e9-8aa6-0d7d4cbf6165.png">